### PR TITLE
Update release-solution-to-prod-with-inputs.yml

### DIFF
--- a/sample-workflows/release-solution-to-prod-with-inputs.yml
+++ b/sample-workflows/release-solution-to-prod-with-inputs.yml
@@ -76,6 +76,7 @@ jobs:
         client-secret: ${{ secrets.envSecret }}
         tenant-id: ${{inputs.TENANT_ID}}
         solution-file: ${{ inputs.solution_outbound_folder}}/${{ inputs.solution_name }}.zip
+        run-asynchronously: true
         force-overwrite: true
         publish-changes: true
 
@@ -119,6 +120,7 @@ jobs:
         app-id: ${{inputs.CLIENT_ID}}
         client-secret: ${{ secrets.envSecret }}
         tenant-id: ${{inputs.TENANT_ID}}
-        solution-file: ${{ inputs.solution_release_folder}}/${{ inputs.solution_name }}_managed.zip
+        solution-file: ${{ inputs.solution_release_folder}}/${{ inputs.solution_name }}.zip
+        run-asynchronously: true
         force-overwrite: true
         publish-changes: true


### PR DESCRIPTION
I think that this file has an inconsistency in the naming for the file between the 'convert-to-managed' and 'release-to-staging' jobs.  Removing "_managed" helped me fix a file-not-found error. The other two release-solution-to-prod sample-workflow files don't have the _managed suffix.

Also I had a timeout on the "Import solution as unmanaged to build env" step, which was resolved by adding "run-asynchronously: true" line.  Which I think is necessary for the "export async function main()" in https://github.com/microsoft/powerplatform-build-tools/blob/main/src/tasks/import-solution/import-solution-v2/index.ts