### PR TITLE
removed unnecessary suffix for exported solution name

### DIFF
--- a/sample-workflows/release-solution-to-prod-with-inputs.yml
+++ b/sample-workflows/release-solution-to-prod-with-inputs.yml
@@ -119,6 +119,6 @@ jobs:
         app-id: ${{inputs.CLIENT_ID}}
         client-secret: ${{ secrets.envSecret }}
         tenant-id: ${{inputs.TENANT_ID}}
-        solution-file: ${{ inputs.solution_release_folder}}/${{ inputs.solution_name }}_managed.zip
+        solution-file: ${{ inputs.solution_release_folder}}/${{ inputs.solution_name }}.zip
         force-overwrite: true
         publish-changes: true


### PR DESCRIPTION
The managed solution is exported in the `Export solution as managed` step of the `convert-to-managed` job with the `solution-output-file` property set as `${{ inputs.solution_shipping_folder}}/${{ inputs.solution_name }}.zip`. The step `Import solution to prod env`  in the  `release-to-staging`  job then tries to reference this file with the `solution-file` property set to `${{ inputs.solution_release_folder}}/${{ inputs.solution_name }}_managed.zip` but this file doesn't exist resulting in a failed workflow run. Removing the `_managed` suffix from the file name that is trying to be resolved solves this issue. 