### PR TITLE
fix: bump upload-artifact@v2 to v4

### DIFF
--- a/.github/workflows/release-solution-to-prod.yml
+++ b/.github/workflows/release-solution-to-prod.yml
@@ -49,7 +49,7 @@ jobs:
         solution-output-file: out/ship/ALMLab.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: out/ship/ALMLab.zip

--- a/sample-workflows/release-solution-env-vars.yml
+++ b/sample-workflows/release-solution-env-vars.yml
@@ -83,7 +83,7 @@ jobs:
         solution-output-file: ${{ env.solution_shipping_folder}}/${{ env.solution_name }}.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ env.solution_shipping_folder}}/${{ env.solution_name }}.zip

--- a/sample-workflows/release-solution-to-prod-with-inputs.yml
+++ b/sample-workflows/release-solution-to-prod-with-inputs.yml
@@ -91,7 +91,7 @@ jobs:
         solution-output-file: ${{ inputs.solution_shipping_folder}}/${{ inputs.solution_name }}_managed.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ inputs.solution_shipping_folder}}/

--- a/sample-workflows/release-solution-to-prod-with-spn-auth.yml
+++ b/sample-workflows/release-solution-to-prod-with-spn-auth.yml
@@ -84,7 +84,7 @@ jobs:
         solution-output-file: ${{ github.event.inputs.solution_shipping_folder}}/${{ github.event.inputs.solution_name }}.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ github.event.inputs.solution_shipping_folder}}/${{ github.event.inputs.solution_name }}.zip

--- a/sample-workflows/release-solution-to-prod.yml
+++ b/sample-workflows/release-solution-to-prod.yml
@@ -78,7 +78,7 @@ jobs:
         solution-output-file: ${{ github.event.inputs.solution_shipping_folder}}/${{ github.event.inputs.solution_name }}.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ github.event.inputs.solution_shipping_folder}}/${{ github.event.inputs.solution_name }}.zip

--- a/sample-workflows/release-solution-with-githubvars.yml
+++ b/sample-workflows/release-solution-with-githubvars.yml
@@ -85,7 +85,7 @@ jobs:
         solution-output-file: ${{ inputs.zip_folder}}/${{ inputs.solution_name }}_managed.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ inputs.zip_folder}}/


### PR DESCRIPTION
- Updates actions/upload-artifact from v2 to v4


Notes:
upload-artifact@v2 was deprecated in June 2024 ([link](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/))