### PR TITLE
fixes for tutorial

### DIFF
--- a/sample-workflows/export-and-branch-solution.yml
+++ b/sample-workflows/export-and-branch-solution.yml
@@ -43,15 +43,18 @@ jobs:
       with:
         lfs: true
 
+    - name: actions-install action
+      uses: microsoft/powerplatform-actions/actions-install@v1
+
     - name: who-am-i action
-      uses: microsoft/powerplatform-actions/who-am-i@v0
+      uses: microsoft/powerplatform-actions/who-am-i@v1
       with:
         environment-url: ${{env.ENVIRONMENT_URL}}
         user-name: ${{env.USERNAME}}
         password-secret: ${{ secrets.password }}
 
     - name: export-solution action
-      uses: microsoft/powerplatform-actions/export-solution@v0
+      uses: microsoft/powerplatform-actions/export-solution@v1
       with:
         environment-url: ${{env.ENVIRONMENT_URL}}
         user-name: ${{env.USERNAME}}
@@ -61,7 +64,7 @@ jobs:
 
 
     - name: unpack-solution action
-      uses: microsoft/powerplatform-actions/unpack-solution@v0
+      uses: microsoft/powerplatform-actions/unpack-solution@v1
       with:
         solution-file: ${{ github.event.inputs.solution_exported_folder}}/${{ github.event.inputs.solution_name }}.zip
         solution-folder: ${{ github.event.inputs.solution_folder}}/${{ github.event.inputs.solution_name }}
@@ -69,7 +72,7 @@ jobs:
         overwrite-files: true
 
     - name: branch-solution, prepare it for a PullRequest
-      uses: microsoft/powerplatform-actions/branch-solution@v0
+      uses: microsoft/powerplatform-actions/branch-solution@v1
       with:
         solution-folder: ${{ github.event.inputs.solution_folder}}/${{ github.event.inputs.solution_name }}
         solution-target-folder: ${{ github.event.inputs.solution_target_folder}}/${{ github.event.inputs.solution_name }}

--- a/sample-workflows/release-solution-to-prod-with-inputs.yml
+++ b/sample-workflows/release-solution-to-prod-with-inputs.yml
@@ -4,23 +4,23 @@ name: release-solution-to-prod-reusable
 # upload the solution to the GitHub artifacts and deploy to the PROD environment
 on:
   workflow_call:
-    inputs: 
+    inputs:
       #Do Not change these values
       #Values are set by the caller
       #caller sample: release-action-call.ymnl
       solution_name:
         description: 'The solution name.'
         type: string
-        default: ALMLab       
+        default: ALMLab
       solution_shipping_folder:
-        description: 'folder name for staging the exported solution *do not change*'        
+        description: 'folder name for staging the exported solution *do not change*'
         type: string
         default: out/ship/
       solution_outbound_folder:
         description: 'staging the unpacked solution folder before check-in *do not change*'
         type: string
         default: out/solutions/
-      solution_source_folder: 
+      solution_source_folder:
        description: 'folder name to be created and checked in *do not change*'
        type: string
        default: solutions/
@@ -31,16 +31,16 @@ on:
       BUILD_ENVIRONMENT_URL:
         description: 'Build environment url.'
         type: string
-        required: true      
-      PRODUCTION_ENVIRONMENT_URL: 
+        required: true
+      PRODUCTION_ENVIRONMENT_URL:
         description: 'Production environment url.'
         type: string
         required: true
-      CLIENT_ID: 
+      CLIENT_ID:
         description: 'The client id'
         type: string
         required: true
-      TENANT_ID: 
+      TENANT_ID:
         description: 'The tenant id'
         type: string
         required: true
@@ -61,15 +61,18 @@ jobs:
       with:
         lfs: true
 
+    - name: actions-install action
+      uses: microsoft/powerplatform-actions/actions-install@v1
+
     - name: Pack solution
-      uses: microsoft/powerplatform-actions/pack-solution@v0
+      uses: microsoft/powerplatform-actions/pack-solution@v1
       with:
         solution-folder: ${{ inputs.solution_source_folder}}/${{ inputs.solution_name }}
         solution-file: ${{ inputs.solution_outbound_folder}}/${{ inputs.solution_name }}.zip
         solution-type: Unmanaged
 
     - name: Import solution as unmanaged to build env
-      uses: microsoft/powerplatform-actions/import-solution@v0
+      uses: microsoft/powerplatform-actions/import-solution@v1
       with:
         environment-url: ${{inputs.BUILD_ENVIRONMENT_URL}}
         app-id: ${{inputs.CLIENT_ID}}
@@ -80,18 +83,18 @@ jobs:
         publish-changes: true
 
     - name: Export solution as managed
-      uses: microsoft/powerplatform-actions/export-solution@v0
+      uses: microsoft/powerplatform-actions/export-solution@v1
       with:
         environment-url: ${{inputs.BUILD_ENVIRONMENT_URL}}
         app-id: ${{inputs.CLIENT_ID}}
-        client-secret: ${{ secrets.envSecret }} 
+        client-secret: ${{ secrets.envSecret }}
         tenant-id: ${{inputs.TENANT_ID}}
         solution-name: ${{ inputs.solution_name }}
         managed: true
         solution-output-file: ${{ inputs.solution_shipping_folder}}/${{ inputs.solution_name }}_managed.zip
 
     - name: Upload the ready to ship solution to GH artifact store
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: managedSolutions
         path: ${{ inputs.solution_shipping_folder}}/
@@ -108,12 +111,16 @@ jobs:
         lfs: true
 
     - name: Fetch the ready to ship solution from GH artifact store
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: managedSolutions
         path: ${{ inputs.solution_release_folder}}
+
+    - name: actions-install action
+      uses: microsoft/powerplatform-actions/actions-install@v1
+
     - name: Import solution to prod env
-      uses: microsoft/powerplatform-actions/import-solution@v0
+      uses: microsoft/powerplatform-actions/import-solution@v1
       with:
         environment-url: ${{inputs.PRODUCTION_ENVIRONMENT_URL}}
         app-id: ${{inputs.CLIENT_ID}}


### PR DESCRIPTION
Customer at Ignite couldn't get the tutorial from https://learn.microsoft.com/en-us/power-platform/alm/tutorials/github-actions-start working.  I tried it myself and had similar issues.  These changes got it working for me.  The changes include updating powerplatform-actions to v1, adding actions-install, and updating artifact actions to v4 as v2 will fail.

NOTE: There are other files in this repo that I suspect also need to be updatd.  This PR only address the files reference in the learn doc.